### PR TITLE
rnmobility.com courses are in sentence case now.

### DIFF
--- a/source/_includes/footer.html
+++ b/source/_includes/footer.html
@@ -258,15 +258,15 @@
 
   const courses = {
     46339924689133: {
-      name: 'ACLS Recertification Course',
+      name: 'ACLS recertification course',
       price: '175.0',
     },
     46339924918509: {
-      name: 'BLS Recertification Course',
+      name: 'BLS recertification course',
       price: '65.0',
     },
     46339925278957: {
-      name: 'PALS Recertification Course',
+      name: 'PALS recertification course',
       price: '175.0',
     },
   };


### PR DESCRIPTION
Change made for https://github.com/acls-training-center/rnmobility.com/pull/83#issuecomment-2562901267